### PR TITLE
T5632: Add user-util jq to parse JSON files from sh

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -25,6 +25,7 @@ Depends:
   iotop,
   ipcalc,
   irqtop,
+  jq,
   libnss-myhostname,
   localepurge,
   lsof,


### PR DESCRIPTION
https://vyos.dev/T5632
Add useful tool "jq" to parse JSON files from sh scripts.
```
vyos@r4# echo '{"system": "VyOS", "rate": 100}' | jq '.system'
"VyOS"
[edit]
vyos@r4# 
```