### PR TITLE
T5222: Remove haproxy from user-utils as it added to vyos-1x

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -18,7 +18,6 @@ Depends:
   exfatprogs,
   fancontrol,
   grepcidr,
-  haproxy,
   haveged,
   htop,
   iftop,


### PR DESCRIPTION
Remove `haproxy` from user-utils as it was added to `vyos-1x debian/control`
https://github.com/vyos/vyos-1x/blob/53bc1627c09d7b6559aaafabfac69a7427e8e38c/debian/control#L67