### PR TITLE
T5984: Add user util numactl

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -33,6 +33,7 @@ Depends:
   ndisc6,
   netcat-openbsd,
   nmap,
+  numactl,
   openssh-client,
   screen,
   sipcalc,


### PR DESCRIPTION
https://vyos.dev/T5984

NUMA scheduling and memory placement tool
```
$ sudo numactl --hardware
available: 2 nodes (0-1)
node 0 cpus: 0 2 4 6 8 10 12 14 16 18 20 22 24 26
node 0 size: 32068 MB
node 0 free: 25571 MB
node 1 cpus: 1 3 5 7 9 11 13 15 17 19 21 23 25 27
node 1 size: 32250 MB
node 1 free: 27038 MB
node distances:
node   0   1 
  0:  10  21 
  1:  21  10 

```