### PR TITLE
T6804: Add ipmitool to user utils

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -23,6 +23,7 @@ Depends:
   iftop,
   iotop,
   ipcalc,
+  ipmitool,
   irqtop,
   jq,
   libnss-myhostname,


### PR DESCRIPTION
## Change Summary
The ipmitool can be immensely helpful if there is an issue or access to the bmc is lost.
Then basic settings can be accessed and set through the still accessible host OS.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Related Task(s)
https://vyos.dev/T6804

## Related PR(s)


## Proposed changes
Adding ipmitool for system management

## How to test
Build and boot image, then run ipmitool (will fail on systems without an BMC).

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
